### PR TITLE
fix bug item not spawning 

### DIFF
--- a/Assets/SOs/EnergyItemSO.asset
+++ b/Assets/SOs/EnergyItemSO.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::BasicItemSO
   itemPrefab: {fileID: 2500205578143049717, guid: 3dbb50a02f98b844eabfadb63c9f4f89, type: 3}
   objectType: 2
-  objectName: 3
+  objectName: 5
   spawnWeight: 30

--- a/Assets/SOs/RocketItemSO.asset
+++ b/Assets/SOs/RocketItemSO.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::BasicItemSO
   itemPrefab: {fileID: 902330265884115229, guid: 19b52fcbf0b793b4e9a13addfee7b835, type: 3}
   objectType: 2
-  objectName: 4
+  objectName: 6
   spawnWeight: 10


### PR DESCRIPTION
public enum ObjectName
{
NONE,
GROUND,
SINGLE_BLOCK,
DOUBLE_BLOCK,
PATTERN_1,
ENERGY_ITEM,
ROCKET_ITEM,
}

해당 Enum 방식으로 SO에 적용할경우, 위 순서가 망가질 떄 기존 SO들의 데이터가 조작됩니다.
enum을 사용하지 않는 방식으로 근본적인 데이터 저장 해결이 필요함.

이번 커밋에선 임시적으로 SO들 데이터를 원 설정대로 복구함.