### PR TITLE
fix spawnable so's enum index error / refac Item in Interface

### DIFF
--- a/Assets/Objects/ObjectSpawner.prefab
+++ b/Assets/Objects/ObjectSpawner.prefab
@@ -145,11 +145,11 @@ MonoBehaviour:
   offsetX: 35
   objectParent: {fileID: 620706635979530757}
   gameManager: {fileID: 0}
-  spawnableList:
-  - {fileID: 11400000, guid: 52f975ea3ddce694b882b14b6da7a0a9, type: 2}
-  - {fileID: 11400000, guid: c03ff0374777ee04c8e6d726ffd65961, type: 2}
+  spawnableObjList:
   - {fileID: 11400000, guid: a8d85e146a08b924ea3046f13ec079a6, type: 2}
   - {fileID: 11400000, guid: b9e9665470739224880c820c4eb84eb6, type: 2}
   - {fileID: 11400000, guid: 0d3554b21ca6c6b418faae1f3ff127ad, type: 2}
+  - {fileID: 11400000, guid: c03ff0374777ee04c8e6d726ffd65961, type: 2}
+  - {fileID: 11400000, guid: 52f975ea3ddce694b882b14b6da7a0a9, type: 2}
   GroundSO: {fileID: 11400000, guid: a779e630f8596ff40b5927d5d303c0a8, type: 2}
   groundPoolParentTransform: {fileID: 7881456204692116621}

--- a/Assets/SOs/DoubleBlockSO.asset
+++ b/Assets/SOs/DoubleBlockSO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: DoubleBlockSO
   m_EditorClassIdentifier: Assembly-CSharp::SpawnableObjectSO
-  itemPrefab: {fileID: 2003619014509062226, guid: e68c3f729d6ea5947a76aba092f92ee9, type: 3}
+  itemPrefabList:
+  - {fileID: 2003619014509062226, guid: e68c3f729d6ea5947a76aba092f92ee9, type: 3}
   objectType: 3
-  objectName: 3
   spawnWeight: 30

--- a/Assets/SOs/EnergyItemSO.asset
+++ b/Assets/SOs/EnergyItemSO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: EnergyItemSO
   m_EditorClassIdentifier: Assembly-CSharp::BasicItemSO
-  itemPrefab: {fileID: 2500205578143049717, guid: 3dbb50a02f98b844eabfadb63c9f4f89, type: 3}
+  itemPrefabList:
+  - {fileID: 2500205578143049717, guid: 3dbb50a02f98b844eabfadb63c9f4f89, type: 3}
   objectType: 2
-  objectName: 5
   spawnWeight: 30

--- a/Assets/SOs/GroundSO.asset
+++ b/Assets/SOs/GroundSO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: GroundSO
   m_EditorClassIdentifier: Assembly-CSharp::SpawnableObjectSO
-  itemPrefab: {fileID: 4102205246358274418, guid: c796ab098ffffbc4f8af3d2e7c9b627d, type: 3}
+  itemPrefabList:
+  - {fileID: 4102205246358274418, guid: c796ab098ffffbc4f8af3d2e7c9b627d, type: 3}
   objectType: 1
-  objectName: 1
   spawnWeight: 0

--- a/Assets/SOs/Pattern1SO.asset
+++ b/Assets/SOs/Pattern1SO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: Pattern1SO
   m_EditorClassIdentifier: Assembly-CSharp::SpawnableObjectSO
-  itemPrefab: {fileID: 1994867180839900513, guid: d3bcd956e2e705143bdcddc8a867bc69, type: 3}
+  itemPrefabList:
+  - {fileID: 1994867180839900513, guid: d3bcd956e2e705143bdcddc8a867bc69, type: 3}
   objectType: 3
-  objectName: 4
   spawnWeight: 70

--- a/Assets/SOs/RocketItemSO.asset
+++ b/Assets/SOs/RocketItemSO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: RocketItemSO
   m_EditorClassIdentifier: Assembly-CSharp::BasicItemSO
-  itemPrefab: {fileID: 902330265884115229, guid: 19b52fcbf0b793b4e9a13addfee7b835, type: 3}
+  itemPrefabList:
+  - {fileID: 902330265884115229, guid: 19b52fcbf0b793b4e9a13addfee7b835, type: 3}
   objectType: 2
-  objectName: 6
   spawnWeight: 10

--- a/Assets/SOs/SingleBlockSO.asset
+++ b/Assets/SOs/SingleBlockSO.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c05894fdd4cfb96409df4a8ce4be9780, type: 3}
   m_Name: SingleBlockSO
   m_EditorClassIdentifier: Assembly-CSharp::SpawnableObjectSO
-  itemPrefab: {fileID: 475648854041163296, guid: 7db2e73dbe62b414aa15e23beb3729f5, type: 3}
+  itemPrefabList:
+  - {fileID: 475648854041163296, guid: 7db2e73dbe62b414aa15e23beb3729f5, type: 3}
   objectType: 3
-  objectName: 2
   spawnWeight: 40

--- a/Assets/Scripts/EnergyBooster.cs
+++ b/Assets/Scripts/EnergyBooster.cs
@@ -1,19 +1,15 @@
 using UnityEngine;
 
-public class EnergyBooster : Item
+public class EnergyBooster : MonoBehaviour, IItem
 {
     [SerializeField] float speedAddition = 2f;
     [SerializeField] float duration = 2f;
     [SerializeField] float healthAddition = 30f;
 
-    void Awake()
-    {
-        itemType = ItemType.ENERGY;
-    }
-
-    public override void GetItem(Player player)
-    {
-       player.GetEnergyBoost(speedAddition, duration, healthAddition);
-       gameObject.SetActive(false);
+    // 25-11-27 TODO-jin : addition / duration err catch넣기
+    public void GetItem(Player player)
+    {    
+        player.GetEnergyBoost(speedAddition, duration, healthAddition);
+        gameObject.SetActive(false);
     }
 }

--- a/Assets/Scripts/Item.cs
+++ b/Assets/Scripts/Item.cs
@@ -1,13 +1,6 @@
 using UnityEngine;
 
-public abstract class Item : MonoBehaviour
+public interface IItem
 {
-    protected ItemType itemType;
-
-    public abstract void GetItem(Player player);
-
-    public ItemType GetItemType()
-    {
-        return itemType;
-    }
+    public void GetItem(Player player);
 }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -27,7 +27,7 @@ public class Player : MonoBehaviour
     public float health {get; private set;}
     bool isItemWorking = false;
     float gainedItemDuration = 0f;
-    Item grabbableItem = null;
+    IItem grabbableItem = null;
 
 
     private void Awake()
@@ -72,7 +72,7 @@ public class Player : MonoBehaviour
 
         if(other.gameObject.CompareTag("Item"))
         {
-            grabbableItem = other.GetComponent<Item>();
+            grabbableItem = other.GetComponent<IItem>();
         }
 
         // Get Block Obj that player stands.

--- a/Assets/Scripts/RocketBooster.cs
+++ b/Assets/Scripts/RocketBooster.cs
@@ -1,16 +1,12 @@
 using UnityEngine;
 
-public class RocketBooster : Item
+public class RocketBooster : MonoBehaviour, IItem
 {
     [SerializeField] float speedAddition = 30f;
     [SerializeField] float duration = 2f;
 
-    void Awake()
-    {
-        itemType = ItemType.ROCKET;
-    }
-
-    public override void GetItem(Player player)
+    // 25-11-27 TODO-jin : addition / duration err catch넣기
+    public void GetItem(Player player)
     {
        player.GetRocketBoost(speedAddition, duration);
        gameObject.SetActive(false);

--- a/Assets/Scripts/SpawnableObjectSO.cs
+++ b/Assets/Scripts/SpawnableObjectSO.cs
@@ -1,12 +1,6 @@
+using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
-
-public enum ItemType
-{
-    NONE,
-    ENERGY,
-    ROCKET,
-}
 
 public enum ObjectType
 {
@@ -16,22 +10,15 @@ public enum ObjectType
     OBSTACLE,
 }
 
-public enum ObjectName
-{
-    NONE,
-    GROUND,
-    SINGLE_BLOCK,
-    DOUBLE_BLOCK,
-    PATTERN_1,
-    ENERGY_ITEM,
-    ROCKET_ITEM,
-}
-
 [CreateAssetMenu(fileName = "ObjectSO", menuName = "SOs/ObjectSO")]
 public class SpawnableObjectSO : ScriptableObject
 {
-    public GameObject itemPrefab;
+    // WARN-jin : 난이도 테마별 프리팹 저장, 난이도 테마 순서대로 저장할것! ex) 0: 이지, 1: 하드, 2: 지옥 테마 프리팹
+    public List<GameObject> itemPrefabList;
     public ObjectType objectType;
-    public ObjectName objectName;
+
+    // 스폰 확률, 100이라고 100퍼 이거만 생성하는건 아님. 누적합 방식 랜덤 뽑기 채용(ObjectSpawner.cs 참조) 
+    // 25-11-27 WARN-jin : 현재 Ground의 경우엔 weight 무시하고 플레이어 위치따라 스폰중임.
+    [Range(0f, 100f)]
     public float spawnWeight;
 }


### PR DESCRIPTION
- 스포너블 obj SO의 item name enum index를 변경시 기존 SO data 작살난거 없앰. 이제 enum이아닌 SO단위로 아이템 종류를 구별함.
- Spawner Code상 쓸모없는 Enum 삭제 관련, Item.cs 및 Player.cs 내 Item 속 Type 참조하던 코드 삭제, 함수밖에없으므로 Item class는 interface로 전환.