### PR TITLE
Fix difficulty system with timescale

### DIFF
--- a/Assets/Objects/GameManager.prefab
+++ b/Assets/Objects/GameManager.prefab
@@ -47,6 +47,8 @@ MonoBehaviour:
   player: {fileID: 0}
   spawner: {fileID: 0}
   scoreManager: {fileID: 0}
-  spdAddForEachDifficulty: 2
-  spawnTimeSec: 5
-  spawnTimeReduceSec: 0.5
+  difficultyMultiply: 1.1
+  defaultSpawnTimeSec: 4
+  minSpawnTimeSec: 0.5
+  curSpawnTimeSec: 0
+  spawnTimer: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -15,7 +15,9 @@ public class GameManager : MonoBehaviour
     
     // VARS
     [Range(1f, 2f)] [SerializeField] float difficultyMultiply = 1.1f;
-    [Range(1f, 10f)][SerializeField] float spawnTimeSec = 5f;
+    [Range(4f, 10f)][SerializeField] float defaultSpawnTimeSec;
+    [Range(0.5f, 2f)][SerializeField] float minSpawnTimeSec = 1f;
+    float curSpawnTimeSec;
     int tilePassCount = 0;
     float spawnTimer = 0f;
     float curTimeScale = 1f;
@@ -31,10 +33,14 @@ public class GameManager : MonoBehaviour
         player.onTilePassing.AddListener(CheckTilePass);
 
         spawner.BlockPoolInitialize();
+
+        SpawnTimerSet(defaultSpawnTimeSec);
+        curTimeScale = Time.timeScale;
     }
 
     void FixedUpdate()
     {
+        SpawnTimeSetBySpeed();
         SpawnTimerRun();
     }
 
@@ -67,10 +73,26 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    void SpawnTimerSet(float spawnTime)
+    {
+        curSpawnTimeSec = spawnTime;
+    }
+
+    void SpawnTimeSetBySpeed()
+    {
+        float speedMult = player.GetCurrentSpeed() / Mathf.Max(0.01f, player.GetBaseSpeed());
+        
+        // DIV BY 0 방지
+        if(speedMult <= 0.01f) return;
+        
+        float nextSpawnTime = Mathf.Max(defaultSpawnTimeSec / curTimeScale / speedMult,  minSpawnTimeSec);
+        SpawnTimerSet(nextSpawnTime);
+    }
+
     void SpawnTimerRun()
     {
         spawnTimer += Time.fixedDeltaTime;
-        if(spawnTimer >= spawnTimeSec)
+        if(spawnTimer >= curSpawnTimeSec)
         {
             spawner.SpawnObject();
             spawnTimer = 0f;

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -241,6 +241,11 @@ public class Player : MonoBehaviour
         return playerMovement.GetCurrentSpeed();
     }
 
+    public float GetBaseSpeed()
+    {
+        return playerMovement.GetBaseSpeed();
+    }
+
     public void IncreaseDefaultSpeed(float addition)
     {
         playerMovement.IncreaseSpeed(addition);

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -91,6 +91,11 @@ public class PlayerMovement : MonoBehaviour
         return baseSpeed + speedAddition;
     }
 
+    public float GetBaseSpeed()
+    {
+        return baseSpeed;
+    }
+
     public void RocketBoost(float rocketSpeed, float duration)
     {
         StartCoroutine(RocketBoostCoroutine(rocketSpeed, duration));
@@ -98,15 +103,15 @@ public class PlayerMovement : MonoBehaviour
 
     System.Collections.IEnumerator RocketBoostCoroutine(float rocketSpeed, float duration)
     {
-        float lastMoveSpeed = baseSpeed;
+        float lastMoveSpeed = speedAddition;
 
-        baseSpeed = rocketSpeed;
+        speedAddition = rocketSpeed;
         rb.useGravity = false;
         isFlying = true;
         isOnRocket = true;
         playerTransform.position = new Vector3(playerTransform.position.x, 10f, playerTransform.position.z);
         yield return new WaitForSeconds(duration);
-        baseSpeed = lastMoveSpeed;
+        speedAddition = lastMoveSpeed;
         rb.useGravity = true;
         isOnRocket = false;
 


### PR DESCRIPTION
난이도 시스템을 player 속도올리기 -> 전체 게임 Timescale 변경으로 바꿉니다
현재 기본 Obj 스폰시간은 default 4s, min 0.5s 로 설정함.
또한 Timescale 상승은 땅 5칸 지날때마다 10% 상승으로 설정함.

-Game Manager IncreaseDifficulty()  로직 변경(현재 플레이어 속도 맞춰 장애물 스폰 속도 조정)
-PlayerMovement.cs 내 Rocket 움직이는함수 base Speed 변경 -> speedAddition 변경하도록
-버그픽스 : 오브젝트 베이스풀 다쓰고있을때, 동일한 장애물 생성시도 시 무한루프갇힘 버그 수정(다른 장애물 생성시도하도록 바꿈)

