### PR TITLE
FIX fist target finding, some code tidy-up in Player.cs

### DIFF
--- a/Assets/Prefabs/Obstacles/2Obstacle.prefab
+++ b/Assets/Prefabs/Obstacles/2Obstacle.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 9025872722514568015}
   m_Layer: 0
   m_Name: 2Obstacle
-  m_TagString: Obstacles
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Obstacles/Pattern1.prefab
+++ b/Assets/Prefabs/Obstacles/Pattern1.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7124284571070166526}
   m_Layer: 0
   m_Name: Pattern1
-  m_TagString: Obstacles
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefabs/Obstacles/SingleObstacle.prefab
+++ b/Assets/Prefabs/Obstacles/SingleObstacle.prefab
@@ -29,11 +29,10 @@ Transform:
   m_GameObject: {fileID: 475648854041163296}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6.87, y: 0.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 10}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 239104822236079118}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &6993660826449597312
@@ -125,115 +124,3 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e47c9867983895a448e9849f3cc47b9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Obstacle
---- !u!1 &2965146657410797924
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 239104822236079118}
-  - component: {fileID: 3657608156053662576}
-  - component: {fileID: 4412129836163915144}
-  - component: {fileID: 173939836184585098}
-  m_Layer: 8
-  m_Name: Plane
-  m_TagString: HitLine
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &239104822236079118
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2965146657410797924}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.51, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 1, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5161179644579220848}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3657608156053662576
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2965146657410797924}
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &4412129836163915144
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2965146657410797924}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RayTracingAccelStructBuildFlagsOverride: 0
-  m_RayTracingAccelStructBuildFlags: 1
-  m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!64 &173939836184585098
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2965146657410797924}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Prefabs/Weapons/FistWeapon.prefab
+++ b/Assets/Prefabs/Weapons/FistWeapon.prefab
@@ -29,7 +29,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 1, z: 1}
+  m_LocalScale: {x: 2, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -95,9 +95,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Fist
   range: {fileID: 0}
-  onObstacleBroken:
-    m_PersistentCalls:
-      m_Calls: []
   targetLayer:
     serializedVersion: 2
     m_Bits: 512

--- a/Assets/Scripts/CoreSystems/Player.cs
+++ b/Assets/Scripts/CoreSystems/Player.cs
@@ -29,7 +29,6 @@ public class Player : MonoBehaviour
     //GameObject currentSteppingBlock = null;
     Dictionary<Type, Weapon> equippedWeapons = new Dictionary<Type, Weapon>();
     GameObject equippedWeaponGO;
-    bool isBlockBreakable = false;
     bool isVulnerable = true;
     public float health {get; private set;}
     bool isItemWorking = false;
@@ -68,11 +67,6 @@ public class Player : MonoBehaviour
             GetDamage(30f);
         }
 
-        if (other.gameObject.CompareTag("HitLine"))
-        {
-            isBlockBreakable = true;
-        }
-
         if(other.gameObject.CompareTag("PassLine"))
         {
             onTilePassing.Invoke();
@@ -92,11 +86,6 @@ public class Player : MonoBehaviour
 
     void OnTriggerExit(Collider other)
     {
-        if (other.gameObject.CompareTag("HitLine"))
-        {
-            isBlockBreakable = false;
-        }
-
         if (other.gameObject.CompareTag("Item"))
         {
             grabbableItem = null;
@@ -107,9 +96,9 @@ public class Player : MonoBehaviour
     {
         if (Mouse.current.leftButton.wasPressedThisFrame)
         {
-            if(isBlockBreakable)
+            if(equippedWeapons[typeof(Fist)].IsAttackable())
             {
-                HitBlock();
+                PunchBlock();
             }
             else if(grabbableItem != null)
             {
@@ -232,16 +221,14 @@ public class Player : MonoBehaviour
         health = Mathf.Max(health - amount, 0f);
     }
 
-    void HitBlock()
+    void PunchBlock()
     {
         equippedWeapons[typeof(Fist)].Attack();
-        isBlockBreakable = false;
     }
 
     void OnBreakingBlock()
     {
         GetHealth(7f);
-        isBlockBreakable = false;
     }
 
     public float GetCurrentSpeed()

--- a/Assets/Scripts/WeaponScripts/Fist.cs
+++ b/Assets/Scripts/WeaponScripts/Fist.cs
@@ -1,11 +1,9 @@
 using UnityEngine;
 
-// 25-11-29 WARN-jin : 현재 장애물 제거 안됨!!!!!!!!!!!!! 수정예정 하단 TODO 참조
 public class Fist : Weapon
 {
     public override void Attack()
     {
-        // 25-11-27 jin : Player에서 이제 Fist 사용 여부 체크할 필요가 없음. 
         if(currentTargetQueue.Count <= 0) return;
 
         currentTargetQueue.Dequeue().gameObject.SetActive(false);
@@ -19,8 +17,7 @@ public class Fist : Weapon
 
     public void OnTriggerEnter(Collider other)
     {
-        // 25-11-29 TODO-jin : HitLine->Obstacle 태그, Range안에 Obstacle이 있으면 되게. 그리고 Range 확줄이기.
-        if(other.gameObject.CompareTag("HitLine"))
+        if(other.gameObject.CompareTag("Obstacles"))
         {
             currentTargetQueue.Enqueue(other.gameObject); 
         }
@@ -28,7 +25,7 @@ public class Fist : Weapon
 
     public void OnTriggerExit(Collider other)
     {
-        if(other.gameObject.CompareTag("HitLine"))
+        if(other.gameObject.CompareTag("Obstacles"))
         {
             currentTargetQueue.Dequeue();
         }
@@ -38,5 +35,10 @@ public class Fist : Weapon
     {
         Debug.Log("FIST LEVEL UP");
         weaponLevel++;
+    }
+    
+    public bool IsFistAttackable()
+    {
+        return currentTargetQueue.Count > 0;
     }
 }

--- a/Assets/Scripts/WeaponScripts/Weapon.cs
+++ b/Assets/Scripts/WeaponScripts/Weapon.cs
@@ -44,4 +44,9 @@ public abstract class Weapon : MonoBehaviour
 
     // 25-11-29 jin : Player가 획득 후 호출하므로 public 
     public abstract void WeaponLevelUp();
+
+    public bool IsAttackable()
+    {
+        return currentTargetQueue.Count > 0;
+    }
 }


### PR DESCRIPTION
Fist 무기가 Hitline이 아닌 Obstacles Tag 자체를 인식해서 지움. 
-더이상 장애물에 주먹 공격 위치인 HitLine 추가할 필요가없음(부술 장애물에 Obstacles Tag 달아야함)
-주먹 range 줄임
-Player.cs에 동일한 로직의 주먹 인식 코드/변수 삭제, 주먹 공격 함수명 명확하게, 