### PR TITLE
fix shuddering on landing

### DIFF
--- a/Assets/Scripts/CoreSystems/PlayerMovement.cs
+++ b/Assets/Scripts/CoreSystems/PlayerMovement.cs
@@ -72,6 +72,8 @@ public class PlayerMovement : MonoBehaviour
                     player.RocketStomp();
                 }
                 RefillJump();
+                // 땅에 착지시 덜컹거리는거 억제
+                rb.linearVelocity = new Vector3(rb.linearVelocity.x, -4f, rb.linearVelocity.z);
                 state = PlayerState.RUN;
 
             } 


### PR DESCRIPTION
로켓 등 높은곳에서 착지시 플레이어 덜컹거리는거 억제합니다.
원인: Rigidbody의 하강 속도가 높아 충돌시 에너지로 인해 약간씩 위로 반발해 튐.
