### PR TITLE
Fix obj kill line size bigger

### DIFF
--- a/Assets/Prefabs/CoreObjects/Player.prefab
+++ b/Assets/Prefabs/CoreObjects/Player.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: -40, y: -0, z: 0}
-  m_LocalScale: {x: 4, y: 3, z: 4}
+  m_LocalScale: {x: 10, y: 15, z: 10}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3058496066040244587}
@@ -388,7 +388,6 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 512
   initLocX: -14
-  fatigueRate: 2
   isDead: 0
 --- !u!114 &7476782402284547059
 MonoBehaviour:


### PR DESCRIPTION
플레이어 오브젝트 킬라인 사이즈가 작아서 삭제가 씹히는 경우가 있음. 두께/넓이 키움