### PR TITLE
fix: increase obj spawner init piece number

### DIFF
--- a/Assets/SOs/ItemSOs/Rocket.asset
+++ b/Assets/SOs/ItemSOs/Rocket.asset
@@ -19,4 +19,3 @@ MonoBehaviour:
   itemGetParticle: {fileID: 5834696962891538266, guid: 618f31880a99b704fa5dd23fed4e743a, type: 3}
   itemName: ROCKET
   speedAddition: 30
-  duration: 2

--- a/Assets/Scripts/CoreSystems/ObjectSpawner.cs
+++ b/Assets/Scripts/CoreSystems/ObjectSpawner.cs
@@ -166,7 +166,7 @@ public class ObjectSpawner : MonoBehaviour
         }
 
         objSpawnerCurXPos = initObjStartXPos;
-        for(int i = 0 ; i < 3 ; i++)
+        for(int i = 0 ; i < 10 ; i++)
         {
             SpawnObjectAsync(ObjectType.ITEM);
         }


### PR DESCRIPTION
게임시작시 3개 오브젝트 생성 -> 10개로 변경.
시작하자마자 로켓먹고 달리면 앞에 텅 빔... => 이거문제는 스폰 위치 변경 간격을 25f에서 30f로 늘리면 될듯.